### PR TITLE
Initial Basic Http Server for Git Repository

### DIFF
--- a/src/main/java/com/github/sparsick/testcontainers/gitserver/GitHttpServerContainer.java
+++ b/src/main/java/com/github/sparsick/testcontainers/gitserver/GitHttpServerContainer.java
@@ -1,0 +1,94 @@
+package com.github.sparsick.testcontainers.gitserver;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.jetbrains.annotations.NotNull;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.images.builder.dockerfile.DockerfileBuilder;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.function.Consumer;
+
+/**
+ * Container for a plain Git HTTP Server based on the Docker image "rockstorm/git-server".
+ */
+public class GitHttpServerContainer extends GenericContainer<GitHttpServerContainer> {
+    private final String gitRepoName = "testRepo";
+
+    private final static DockerImageName DEFAULT_DOCKER_IMAGE_NAME = DockerImageName.parse("rockstorm/git-server");
+
+
+    /**
+     * @param dockerImageName - name of the docker image
+     */
+    public GitHttpServerContainer(DockerImageName dockerImageName) {
+        super(new ImageFromDockerfile()
+                .withFileFromClasspath("http-config/nginx.conf", "http-config/nginx.conf")
+                .withDockerfileFromBuilder(dockerfileBuilder(dockerImageName)));
+        dockerImageName.assertCompatibleWith(DEFAULT_DOCKER_IMAGE_NAME);
+
+        if ("2.38".compareTo(dockerImageName.getVersionPart()) <= 0) {
+            waitingFor(Wait.forLogMessage(".*Container configuration completed.*", 1)).addExposedPorts(80);
+        } else {
+            withExposedPorts(80);
+        }
+    }
+
+    @NotNull
+    private static Consumer<DockerfileBuilder> dockerfileBuilder(DockerImageName dockerImageName) {
+        final String updateGit;
+        if ("2.36".compareTo(dockerImageName.getVersionPart()) == 0) {
+            updateGit = "apk add --update git=2.36.6-r0 && ";
+        } else if ("2.34".compareTo(dockerImageName.getVersionPart()) == 0) {
+            updateGit = "apk add --update git=2.34.8-r0 && ";
+        } else {
+            updateGit = "";
+        }
+
+        return builder ->
+                builder
+                        .from(dockerImageName.toString())
+                        .run("apk add --update nginx && " +
+                                updateGit +
+                                "apk add --update git-daemon &&" +
+                                "apk add --update fcgiwrap &&" +
+                                "apk add --update spawn-fcgi && " +
+                                "rm -rf /var/cache/apk/*")
+                        .copy("./http-config/nginx.conf", "/etc/nginx/nginx.conf")
+                        .cmd("spawn-fcgi -s /run/fcgi.sock /usr/bin/fcgiwrap && " +
+                                "    nginx -g \"daemon off;\"")
+                        .build();
+    }
+
+    /**
+     * Return the HTTP URI for git repo.
+     *
+     * @return HTTP URI
+     */
+    public URI getGitRepoURIAsHttp() {
+        return URI.create("http://"+ getHost()+":" + getMappedPort(80) + "/git/"+gitRepoName);
+    }
+
+    @Override
+    protected void containerIsStarted(InspectContainerResponse containerInfo) {
+        super.containerIsStarted(containerInfo);
+        configureGitRepository();
+    }
+
+    private void configureGitRepository()  {
+        try {
+            String gitRepoPath = String.format("/srv/git/%s.git", gitRepoName);
+            execInContainer("mkdir", "-p", gitRepoPath);
+            execInContainer("git", "init", "--bare", gitRepoPath);
+            execInContainer("sh", "-c", "echo '[http]' >> " + gitRepoPath + "/config");
+            execInContainer("sh", "-c", "echo '        receivepack = true' >> " + gitRepoPath + "/config");
+            execInContainer("chown", "-R", "git:git", "/srv");
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Configure Git repository failed",e);
+
+        }
+    }
+}

--- a/src/main/resources/http-config/nginx.conf
+++ b/src/main/resources/http-config/nginx.conf
@@ -1,0 +1,41 @@
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log;
+pid /run/nginx.pid;
+user root;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    server {
+        listen  *:80;
+
+        root /www/empty/;
+        index index.html;
+
+        server_name $hostname;
+        access_log /var/log/nginx/access.log;
+
+        #error_page 404 /404.html;
+
+        #auth_basic            "Restricted";
+        #auth_basic_user_file  /www/htpasswd;
+
+        location ~ /git(/.*) {
+            # Set chunks to unlimited, as the bodies can be huge
+            client_max_body_size            0;
+
+            fastcgi_param SCRIPT_FILENAME /usr/libexec/git-core/git-http-backend;
+            include fastcgi_params;
+            fastcgi_param GIT_HTTP_EXPORT_ALL "";
+            fastcgi_param GIT_PROJECT_ROOT /srv/git;
+            fastcgi_param PATH_INFO $1;
+
+            # Forward REMOTE_USER as we want to know when we are authenticated
+            fastcgi_param   REMOTE_USER     $remote_user;
+            fastcgi_pass    unix:/run/fcgi.sock;
+        }
+    }
+}

--- a/src/test/java/com/github/sparsick/testcontainers/gitserver/GitHttpServerContainerTest.java
+++ b/src/test/java/com/github/sparsick/testcontainers/gitserver/GitHttpServerContainerTest.java
@@ -1,0 +1,39 @@
+package com.github.sparsick.testcontainers.gitserver;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class GitHttpServerContainerTest {
+
+    @TempDir(cleanup = CleanupMode.NEVER)
+    private File tempDir;
+
+    @ParameterizedTest
+    @EnumSource(GitServerVersions.class)
+    void cloneWithoutAuthentication(GitServerVersions gitServerVersions) throws GitAPIException, IOException {
+        GitHttpServerContainer containerUnderTest = new GitHttpServerContainer(gitServerVersions.getDockerImageName());
+        containerUnderTest.start();
+
+        Git git = Git.cloneRepository()
+                .setURI(containerUnderTest.getGitRepoURIAsHttp().toString())
+                .setDirectory(tempDir)
+                .call();
+
+        assertThat(new File(tempDir, ".git")).exists();
+
+        new File(tempDir, "test.txt").createNewFile();
+        git.add().addFilepattern(".").call();
+        git.commit().setMessage("test").call();
+        git.push().call();
+    }
+}


### PR DESCRIPTION
Current functionality is to provide a Git repository without authentication or HTTPS.


fix #32 