### PR TITLE
Fix file permission for pubKey Auth 

### DIFF
--- a/testcontainers-gitserver/src/main/java/com/github/sparsick/testcontainers/gitserver/plain/GitServerContainer.java
+++ b/testcontainers-gitserver/src/main/java/com/github/sparsick/testcontainers/gitserver/plain/GitServerContainer.java
@@ -114,6 +114,18 @@ public class GitServerContainer extends GenericContainer<GitServerContainer> {
         super.containerIsStarted(containerInfo);
             configureGitRepository();
             collectHostKeyInformation();
+            fixFilePermissions();
+    }
+
+    /**
+     * Wrong file permissions cause authentication to fail.
+     */
+    private void fixFilePermissions() {
+        try {
+            execInContainer("chmod", "600", "/home/git/.ssh/authorized_keys");
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Could not fix file permissions on /home/git/.ssh/authorized_keys", e);
+        }
     }
 
     private void collectHostKeyInformation() {

--- a/testcontainers-gitserver/src/test/java/com/github/sparsick/testcontainers/gitserver/plain/GitServerContainerTest.java
+++ b/testcontainers-gitserver/src/test/java/com/github/sparsick/testcontainers/gitserver/plain/GitServerContainerTest.java
@@ -18,15 +18,20 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -39,7 +44,11 @@ public class GitServerContainerTest {
     private File tempDir;
 
 
-
+    static Stream<Arguments> publicKeySupportedVersions () {
+        return Arrays.stream(GitServerVersions.values())
+            .filter(v -> !(v == GitServerVersions.V2_36 || v == GitServerVersions.V2_34_2 || v == GitServerVersions.V2_34))
+            .map(Arguments::of);
+    }
 
     @Test
     void validDockerImageName() {
@@ -168,7 +177,7 @@ public class GitServerContainerTest {
     }
 
     @ParameterizedTest
-    @EnumSource(GitServerVersions.class)
+    @MethodSource("publicKeySupportedVersions")
     void pubKeyAuth(GitServerVersions gitServer) {
         var containerUnderTest = new GitServerContainer(gitServer.getDockerImageName()).withSshKeyAuth();
 
@@ -189,7 +198,8 @@ public class GitServerContainerTest {
 
 
     @ParameterizedTest
-    @EnumSource(GitServerVersions.class)
+//    @EnumSource(GitServerVersions.class)
+    @MethodSource("publicKeySupportedVersions")
     void strictHostKeyVerifivation(GitServerVersions gitServer) {
         var containerUnderTest = new GitServerContainer(gitServer.getDockerImageName()).withSshKeyAuth();
 


### PR DESCRIPTION
fix permissions on authorized_keys, exclude some old versions for pubkey auth, due to missing support for encryption alg
This should fix #70 

All unit tests with pubkey Auth fail on my machine, strange that the build on github succeeds

May it is easier to remove support for the older image versions