### PR TITLE
 GitHttpServer broken by git/git-daemon Alpine update

### DIFF
--- a/testcontainers-gitserver/src/main/java/com/github/sparsick/testcontainers/gitserver/http/GitHttpServerContainer.java
+++ b/testcontainers-gitserver/src/main/java/com/github/sparsick/testcontainers/gitserver/http/GitHttpServerContainer.java
@@ -55,7 +55,6 @@ public class GitHttpServerContainer extends GenericContainer<GitHttpServerContai
                     .from(dockerImageName.toString())
                     .run("apk add --update nginx && " +
                             checkUpdateGit(dockerImageName) +
-                            "apk add --update git git-daemon && " +
                             "apk add --update fcgiwrap && " +
                             "apk add --update spawn-fcgi && " +
                             checkIfOpensslIsNeeded(basicAuthenticationCredentials) +
@@ -91,11 +90,11 @@ public class GitHttpServerContainer extends GenericContainer<GitHttpServerContai
     private static String checkUpdateGit(DockerImageName dockerImageName) {
         final String updateGit;
         if ("2.36".compareTo(dockerImageName.getVersionPart()) == 0) {
-            updateGit = "apk add --update git=2.36.6-r0 && ";
+            updateGit = "apk add --update git=2.36.6-r0 git-daemon=2.36.6-r0 && ";
         } else if ("2.34".compareTo(dockerImageName.getVersionPart()) == 0) {
-            updateGit = "apk add --update git=2.34.8-r0 && ";
+            updateGit = "apk add --update git=2.34.8-r0 git-daemon=2.34.8-r0 && ";
         } else {
-            updateGit = "";
+            updateGit = "apk add --update git git-daemon && ";
         }
         return updateGit;
     }

--- a/testcontainers-gitserver/src/main/java/com/github/sparsick/testcontainers/gitserver/http/GitHttpServerContainer.java
+++ b/testcontainers-gitserver/src/main/java/com/github/sparsick/testcontainers/gitserver/http/GitHttpServerContainer.java
@@ -68,7 +68,7 @@ public class GitHttpServerContainer extends GenericContainer<GitHttpServerContai
 
             }
 
-            tempBuilder.cmd("spawn-fcgi -s /run/fcgi.sock /usr/bin/fcgiwrap && " +
+            tempBuilder.cmd("spawn-fcgi -s /run/fcgi.sock -- /usr/bin/fcgiwrap -f && " +
                             "    nginx -g \"daemon off;\"")
                     .build();
 

--- a/testcontainers-gitserver/src/main/java/com/github/sparsick/testcontainers/gitserver/http/GitHttpServerContainer.java
+++ b/testcontainers-gitserver/src/main/java/com/github/sparsick/testcontainers/gitserver/http/GitHttpServerContainer.java
@@ -55,8 +55,8 @@ public class GitHttpServerContainer extends GenericContainer<GitHttpServerContai
                     .from(dockerImageName.toString())
                     .run("apk add --update nginx && " +
                             checkUpdateGit(dockerImageName) +
-                            "apk add --update git-daemon &&" +
-                            "apk add --update fcgiwrap &&" +
+                            "apk add --update git git-daemon && " +
+                            "apk add --update fcgiwrap && " +
                             "apk add --update spawn-fcgi && " +
                             checkIfOpensslIsNeeded(basicAuthenticationCredentials) +
                             "rm -rf /var/cache/apk/*")

--- a/testcontainers-gitserver/src/main/java/com/github/sparsick/testcontainers/gitserver/http/GitHttpServerContainer.java
+++ b/testcontainers-gitserver/src/main/java/com/github/sparsick/testcontainers/gitserver/http/GitHttpServerContainer.java
@@ -60,12 +60,12 @@ public class GitHttpServerContainer extends GenericContainer<GitHttpServerContai
                             "apk add --update spawn-fcgi && " +
                             checkIfOpensslIsNeeded(basicAuthenticationCredentials) +
                             "rm -rf /var/cache/apk/*")
-                    .copy("./http-config/nginx.conf", "/etc/nginx/nginx.conf");
+                    .copy("./http-config/nginx.conf", "/etc/nginx/nginx.conf")
+                    .run("git config --global --add safe.directory '*'");
 
             if (basicAuthenticationCredentials != null) {
                 tempBuilder.run("sh", "-c", "echo \"" + basicAuthenticationCredentials.getUsername() + ":$(openssl passwd -apr1 " + basicAuthenticationCredentials.getPassword() + ")\" > /etc/nginx/.htpasswd");
                 tempBuilder.run("sh", "-c", "sed -i -e 's/#auth_basic/auth_basic/g' /etc/nginx/nginx.conf");
-
             }
 
             tempBuilder.cmd("spawn-fcgi -s /run/fcgi.sock -- /usr/bin/fcgiwrap -f && " +

--- a/testcontainers-gitserver/src/test/java/com/github/sparsick/testcontainers/gitserver/http/GitHttpServerContainerTest.java
+++ b/testcontainers-gitserver/src/test/java/com/github/sparsick/testcontainers/gitserver/http/GitHttpServerContainerTest.java
@@ -4,6 +4,7 @@ import com.github.sparsick.testcontainers.gitserver.GitServerVersions;
 import org.assertj.core.api.ThrowableAssert;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.TransportException;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
@@ -14,7 +15,7 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatException;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 
 
 public class GitHttpServerContainerTest {
@@ -48,7 +49,9 @@ public class GitHttpServerContainerTest {
                 .setURI(containerUnderTest.getGitRepoURIAsHttp().toString())
                 .setDirectory(tempDir)
                 .call();
-        assertThatException().isThrownBy(tryingClone);
+        TransportException expectedException = catchThrowableOfType(tryingClone, TransportException.class);
+        assertThat(expectedException).isNotNull();
+        assertThat(expectedException).hasMessageContaining("Authentication is required");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Adding `git` to the `apk add` statement appears to let the container build, however the tests still fail with an `500: Internal Server error` at a later stage.

Will update the associated issue.